### PR TITLE
Joda Period generators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: scala
+scala:
+   - 2.11.7

--- a/build.sbt
+++ b/build.sbt
@@ -8,4 +8,3 @@ libraryDependencies ++= Seq(
   "org.scalacheck" %% "scalacheck" % "1.13.0",
   "joda-time" % "joda-time" % "2.9.4"
 )
-

--- a/src/main/scala/com/fortysevendeg/scalacheck/datetime/GenDateTime.scala
+++ b/src/main/scala/com/fortysevendeg/scalacheck/datetime/GenDateTime.scala
@@ -29,17 +29,10 @@ object GenDateTime {
   )
 
   /**
-    * Given a <code>period</code>, this will generate <code>DateTime</code>s either side of <code>dateTime</code>
+    * Generates a <code>DateTime</code> between the given <code>dateTime> and the end of the <code>period</code>
     */
-  def genDateTimeBeforeAndAfter(dateTime: DateTime, period: ReadablePeriod): Gen[DateTime] = {
-    val diffMillis = Math.abs(dateTime.plus(period).getMillis() - dateTime.getMillis())
-    Gen.choose(-diffMillis, diffMillis).map(millis => dateTime.plus(millis))
-  }
-
-  /**
-    *
-    */
-  def genDateTimeForPeriod(dateTime: DateTime, period: ReadablePeriod): Gen[DateTime] = {
-    ???
+  def genDateTimeWithinPeriod(dateTime: DateTime, period: ReadablePeriod): Gen[DateTime] = {
+    val diffMillis = dateTime.plus(period).getMillis() - dateTime.getMillis()
+    Gen.choose(0L min diffMillis, 0L max diffMillis).map(millis => dateTime.plus(millis))
   }
 }

--- a/src/main/scala/com/fortysevendeg/scalacheck/datetime/GenDateTime.scala
+++ b/src/main/scala/com/fortysevendeg/scalacheck/datetime/GenDateTime.scala
@@ -6,30 +6,49 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.joda.time._
 
 /**
-  * Some generators for working with dates and times
+  * Some generators for working with dates and times.
   */
 object GenDateTime {
 
+
+  /** A <code>Years</code> period generator. */
   val genYearsPeriod: Gen[Years] = Gen.choose(-292275054, 292278993).map(Years.ZERO.plus(_)) // Years.MIN_VALUE produces exception-throwing results
+
+  /** A <code>Months</code> period generator. */
   val genMonthsPeriod: Gen[Months] = Gen.choose(Months.MIN_VALUE.getMonths, Months.MAX_VALUE.getMonths).map(Months.ZERO.plus(_))
+
+  /** A <code>Weeks</code> period generator. */
   val genWeeksPeriod: Gen[Weeks] = Gen.choose(Weeks.MIN_VALUE.getWeeks, Weeks.MAX_VALUE.getWeeks).map(Weeks.ZERO.plus(_))
+
+  /** A <code>Days</code> period generator. */
   val genDaysPeriod: Gen[Days] = Gen.choose(Days.MIN_VALUE.getDays, Days.MAX_VALUE.getDays).map(Days.ZERO.plus(_))
+
+  /** A <code>Hours</code> period generator. */
   val genHoursPeriod: Gen[Hours] = Gen.choose(Hours.MIN_VALUE.getHours, Hours.MAX_VALUE.getHours).map(Hours.ZERO.plus(_))
+
+  /** A <code>Minutes</code> period generator. */
   val genMinutesPeriod: Gen[Minutes] = Gen.choose(Minutes.MIN_VALUE.getMinutes, Minutes.MAX_VALUE.getMinutes).map(Minutes.ZERO.plus(_))
+
+  /** A <code>Seconds</code> period generator. */
   val genSecondsPeriod: Gen[Seconds] = Gen.choose(Seconds.MIN_VALUE.getSeconds, Seconds.MAX_VALUE.getSeconds).map(Seconds.ZERO.plus(_))
 
-  val genPeriod: Gen[ReadablePeriod] = Gen.oneOf(
-    genYearsPeriod,
-    genMonthsPeriod,
-    genWeeksPeriod,
-    genDaysPeriod,
-    genHoursPeriod,
-    genMinutesPeriod,
-    genSecondsPeriod
-  )
+  /**
+    * A <code>Period</code> generator consisting of years, days, hours, minutes, seconds and millis.
+    */
+  val genPeriod: Gen[Period] = for {
+    years <- genYearsPeriod
+    days <- Gen.choose(1, 365)
+    hours <- Gen.choose(0, 23)
+    minutes <- Gen.choose(0, 59)
+    seconds <- Gen.choose(0, 59)
+    millis <- Gen.choose(0, 999)
+  } yield Period.years(years.getYears).withDays(days).withHours(hours).withMinutes(minutes).withSeconds(seconds).withMillis(millis)
 
   /**
-    * Generates a <code>DateTime</code> between the given <code>dateTime> and the end of the <code>period</code>
+    * Generates a <code>DateTime</code> between the given <code>dateTime</code>x and the end of the <code>period</code>
+    * @param dateTime A <code>DateTime</code> to calculate the period offsets from.
+    * @param period An offset from <code>dateTime</code>, serving as an upper bound for generated <code>DateTime</code>s. Can be negative, denoting an offset <i>before</i> the provided <code>DateTime</code>.
+    * @return A <code>DateTime</code> generator for <code>DateTime</code>s within the expected range.
     */
   def genDateTimeWithinPeriod(dateTime: DateTime, period: ReadablePeriod): Gen[DateTime] = {
     val diffMillis = dateTime.plus(period).getMillis() - dateTime.getMillis()

--- a/src/main/scala/com/fortysevendeg/scalacheck/datetime/GenDateTime.scala
+++ b/src/main/scala/com/fortysevendeg/scalacheck/datetime/GenDateTime.scala
@@ -1,0 +1,45 @@
+package com.fortysevendeg.scalacheck.datetime
+
+import org.scalacheck.Gen
+import org.scalacheck.Arbitrary.arbitrary
+
+import org.joda.time._
+
+/**
+  * Some generators for working with dates and times
+  */
+object GenDateTime {
+
+  val genYearsPeriod: Gen[Years] = Gen.choose(-292275054, 292278993).map(Years.ZERO.plus(_)) // Years.MIN_VALUE produces exception-throwing results
+  val genMonthsPeriod: Gen[Months] = Gen.choose(Months.MIN_VALUE.getMonths, Months.MAX_VALUE.getMonths).map(Months.ZERO.plus(_))
+  val genWeeksPeriod: Gen[Weeks] = Gen.choose(Weeks.MIN_VALUE.getWeeks, Weeks.MAX_VALUE.getWeeks).map(Weeks.ZERO.plus(_))
+  val genDaysPeriod: Gen[Days] = Gen.choose(Days.MIN_VALUE.getDays, Days.MAX_VALUE.getDays).map(Days.ZERO.plus(_))
+  val genHoursPeriod: Gen[Hours] = Gen.choose(Hours.MIN_VALUE.getHours, Hours.MAX_VALUE.getHours).map(Hours.ZERO.plus(_))
+  val genMinutesPeriod: Gen[Minutes] = Gen.choose(Minutes.MIN_VALUE.getMinutes, Minutes.MAX_VALUE.getMinutes).map(Minutes.ZERO.plus(_))
+  val genSecondsPeriod: Gen[Seconds] = Gen.choose(Seconds.MIN_VALUE.getSeconds, Seconds.MAX_VALUE.getSeconds).map(Seconds.ZERO.plus(_))
+
+  val genPeriod: Gen[ReadablePeriod] = Gen.oneOf(
+    genYearsPeriod,
+    genMonthsPeriod,
+    genWeeksPeriod,
+    genDaysPeriod,
+    genHoursPeriod,
+    genMinutesPeriod,
+    genSecondsPeriod
+  )
+
+  /**
+    * Given a <code>period</code>, this will generate <code>DateTime</code>s either side of <code>dateTime</code>
+    */
+  def genDateTimeBeforeAndAfter(dateTime: DateTime, period: ReadablePeriod): Gen[DateTime] = {
+    val diffMillis = Math.abs(dateTime.plus(period).getMillis() - dateTime.getMillis())
+    Gen.choose(-diffMillis, diffMillis).map(millis => dateTime.plus(millis))
+  }
+
+  /**
+    *
+    */
+  def genDateTimeForPeriod(dateTime: DateTime, period: ReadablePeriod): Gen[DateTime] = {
+    ???
+  }
+}

--- a/src/test/scala/com/fortysevendeg/scalacheck/datetime/GenDateTimeProperties.scala
+++ b/src/test/scala/com/fortysevendeg/scalacheck/datetime/GenDateTimeProperties.scala
@@ -11,7 +11,7 @@ import GenDateTime._
 object GenDateTimeProperties extends Properties("Date Time Generators") {
 
   /*
-   *  These properties check that the construction of the periods does not fail. Some (like years) have a restricted range of values.
+   * These properties check that the construction of the periods does not fail. Some (like years) have a restricted range of values.
    */
 
   property("genYearsPeriod creates valid year periods")     = forAll(genYearsPeriod)   { _ => passed }
@@ -28,6 +28,8 @@ object GenDateTimeProperties extends Properties("Date Time Generators") {
 
   property("genSecondsPeriod creates valid second periods") = forAll(genSecondsPeriod) { _ => passed }
 
+  property("genPeriod creates valid periods containing a selection of other periods") = forAll(genPeriod) { _ => passed }
+
   property("genDateTimeWithinPeriod should generate DateTimes between the given date and the end of the specified period") = forAll(genPeriod) { p =>
 
     val now = new DateTime()
@@ -42,11 +44,10 @@ object GenDateTimeProperties extends Properties("Date Time Generators") {
                           |Generated:       $generated
                           |Period Boundary: $periodBoundary""".stripMargin
 
-      val check = if (periodBoundary.isAfter(now)) { // period is positive
-        (now.isBefore(generated) || now.isEqual(generated)) && (periodBoundary.isAfter(generated) || periodBoundary.isEqual(generated))
-      } else { // period is negative
-        (periodBoundary.isBefore(generated) || periodBoundary.isEqual(generated)) && (now.isAfter(generated) || now.isEqual(generated))
-      }
+      val (lowerBound, upperBound) = if(periodBoundary.isAfter(now)) (now, periodBoundary) else (periodBoundary, now)
+
+      val check = (lowerBound.isBefore(generated) || lowerBound.isEqual(generated)) &&
+                  (upperBound.isAfter(generated)  || upperBound.isEqual(generated))
 
       check :| resultText
     }

--- a/src/test/scala/com/fortysevendeg/scalacheck/datetime/GenDateTimeProperties.scala
+++ b/src/test/scala/com/fortysevendeg/scalacheck/datetime/GenDateTimeProperties.scala
@@ -1,0 +1,57 @@
+package com.fortysevendeg.scalacheck.datetime
+
+import org.scalacheck._
+import org.scalacheck.Prop._
+
+import org.joda.time._
+import org.joda.time.format.PeriodFormat
+
+import GenDateTime._
+
+object GenDateTimeProperties extends Properties("Date Time Generators") {
+
+  /*
+   *  These properties check that the construction of the periods does not fail. Some (like years) have a restricted range of values.
+   */
+
+  property("genYearsPeriod creates valid year periods")     = forAll(genYearsPeriod)   { _ => passed }
+
+  property("genMonthsPeriod creates valid month periods")   = forAll(genMonthsPeriod)  { _ => passed }
+
+  property("genWeeksPeriod creates valid week periods")     = forAll(genWeeksPeriod)   { _ => passed }
+
+  property("genDaysPeriod creates valid day periods")       = forAll(genDaysPeriod)    { _ => passed }
+
+  property("genHoursPeriod creates valid hour periods")     = forAll(genHoursPeriod)   { _ => passed }
+
+  property("genMinutesPeriod creates valid minute periods") = forAll(genMinutesPeriod) { _ => passed }
+
+  property("genSecondsPeriod creates valid second periods") = forAll(genSecondsPeriod) { _ => passed }
+
+  property("genDateTimeBeforeAndAfter should only be generated within the specified period, both before and after the given time") = forAll(genPeriod) { p =>
+
+    val now = new DateTime()
+
+    forAll(genDateTimeBeforeAndAfter(now, p)) { generated =>
+
+      // if period is negative, then "maxBoundary" will be before now, and vice versa
+      val maxBoundary = now.plus(p)
+      val minBoundary = now.minus(p)
+
+      val resultText = s"""Period:       ${PeriodFormat.getDefault().print(p)}
+                          |Now:          $now
+                          |Generated:    $generated
+                          |Min boundary: $minBoundary
+                          |Max Boundary: $maxBoundary""".stripMargin
+
+      val check = if (minBoundary.isBefore(now)) { // period is positive
+        (minBoundary.isBefore(generated) || minBoundary.isEqual(generated)) && (maxBoundary.isAfter(generated) || maxBoundary.isEqual(generated))
+      } else { // period is negative
+        (maxBoundary.isBefore(generated) || maxBoundary.isEqual(generated)) && (minBoundary.isAfter(generated) || minBoundary.isEqual(generated))
+
+      }
+
+      check :| resultText
+    }
+  }
+}

--- a/src/test/scala/com/fortysevendeg/scalacheck/datetime/GenDateTimeProperties.scala
+++ b/src/test/scala/com/fortysevendeg/scalacheck/datetime/GenDateTimeProperties.scala
@@ -28,27 +28,24 @@ object GenDateTimeProperties extends Properties("Date Time Generators") {
 
   property("genSecondsPeriod creates valid second periods") = forAll(genSecondsPeriod) { _ => passed }
 
-  property("genDateTimeBeforeAndAfter should only be generated within the specified period, both before and after the given time") = forAll(genPeriod) { p =>
+  property("genDateTimeWithinPeriod should generate DateTimes between the given date and the end of the specified period") = forAll(genPeriod) { p =>
 
     val now = new DateTime()
 
-    forAll(genDateTimeBeforeAndAfter(now, p)) { generated =>
+    forAll(genDateTimeWithinPeriod(now, p)) { generated =>
 
-      // if period is negative, then "maxBoundary" will be before now, and vice versa
-      val maxBoundary = now.plus(p)
-      val minBoundary = now.minus(p)
+      // if period is negative, then periodBoundary will be before now
+      val periodBoundary = now.plus(p)
 
-      val resultText = s"""Period:       ${PeriodFormat.getDefault().print(p)}
-                          |Now:          $now
-                          |Generated:    $generated
-                          |Min boundary: $minBoundary
-                          |Max Boundary: $maxBoundary""".stripMargin
+      val resultText = s"""Period:          ${PeriodFormat.getDefault().print(p)}
+                          |Now:             $now
+                          |Generated:       $generated
+                          |Period Boundary: $periodBoundary""".stripMargin
 
-      val check = if (minBoundary.isBefore(now)) { // period is positive
-        (minBoundary.isBefore(generated) || minBoundary.isEqual(generated)) && (maxBoundary.isAfter(generated) || maxBoundary.isEqual(generated))
+      val check = if (periodBoundary.isAfter(now)) { // period is positive
+        (now.isBefore(generated) || now.isEqual(generated)) && (periodBoundary.isAfter(generated) || periodBoundary.isEqual(generated))
       } else { // period is negative
-        (maxBoundary.isBefore(generated) || maxBoundary.isEqual(generated)) && (minBoundary.isAfter(generated) || minBoundary.isEqual(generated))
-
+        (periodBoundary.isBefore(generated) || periodBoundary.isEqual(generated)) && (now.isAfter(generated) || now.isEqual(generated))
       }
 
       check :| resultText


### PR DESCRIPTION
Generators for Joda Period classes:
  * Full-range generators for the different Period types (Years, Months, Weeks, Days, Hours, Minutes, Seconds)
  * Full-range generator for a Period consisting of years, days, hours, minutes, seconds, milliseconds
  * A generator method taking a DateTime and a Period, and this will generate a DateTime between the given DateTime and the offset given by the period. Note this is different from previous discussions (which was DateTime ± Period), as I believe this makes things a little clearer.

```
   DateTime
      ▼
<-----|------------------------------------------|------------->

      ~------------------------------------------~
                        ▲
                 Period (range)
```

Everything seems quite straightforward right now, but I'd love to get some early input on the code, as well as some fundamental things like:
  * Package name: One idea could be to change the package to `org.scalacheck.datetime` or similar, copying other libraries such as [scalacheck-shapeless](https://github.com/alexarchambault/scalacheck-shapeless/blob/master/core/shared/src/main/scala/org/scalacheck/Shapeless.scala#L1).

1.   Class names. I expect I'll add an ArbitraryDateTime sometime soon containing sensible default arbitraries.
2.   Other generator methods. I was thinking of adding some "helper" generators which defer to `genDateTimeWithinPeriod`, by calculating the correct parameters, such as methods which take:


A period either side of a DateTime (as noted above):

```
                       DT
                       ▼
<-----|----------------|----------------|------------->

      ~----------------~----------------~
              ▲               ▲
              P               P
```


Two periods, so that the offset either side of the given DateTime can be different:


```
                       DT
                       ▼
<-----|----------------|-------|------------->

      ~----------------~-------~
              ▲            ▲
              P1           P2
```

Note these two suggestions are not completely logical as a period has a notion of being positive or negative, and there's no abstraction that represents just the _magnitude_ of a period (what does it mean to have a negative period for the time before the given DateTime???), I'm half thinking of just including documentation as to how to do this, to keep the API clean and reducing confusion due to ambiguity.

Finally, just to mention this code so far is only for Joda's classes, I intend to update this to generate different classes from other libraries, such as Java 8's Date and Time API.

Closes #1 