### PR TITLE
Java 8 Date Time support: typeclasses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 target/*
 project/target/*
+project/project/target/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ scala:
 
 jdk:
   - oraclejdk8
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: scala
 scala:
    - 2.11.7
+
+jdk:
+  - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ jdk:
   - oraclejdk8
 
 after_success:
+  - sbt coverageReport
   - bash <(curl -s https://codecov.io/bash) -t d8c6d7cf-f05c-4953-9f6e-ff046716a0f0

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: scala
 scala:
    - 2.11.7
 
+script:
+  - sbt ++$TRAVIS_SCALA_VERSION clean coverage test
+
 jdk:
   - oraclejdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ jdk:
   - oraclejdk8
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://codecov.io/bash) -t d8c6d7cf-f05c-4953-9f6e-ff046716a0f0

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+scalacheck-datetime
+====
+
+[![Build Status](https://travis-ci.org/47deg/scalacheck-datetime.svg?branch=master)](https://travis-ci.org/47deg/scalacheck-datetime)
+
+A helper library for using datetime libraries with ScalaCheck

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")

--- a/src/main/scala/com/fortysevendeg/scalacheck/datetime/GenDateTime.scala
+++ b/src/main/scala/com/fortysevendeg/scalacheck/datetime/GenDateTime.scala
@@ -3,46 +3,12 @@ package com.fortysevendeg.scalacheck.datetime
 import org.scalacheck.Gen
 import org.scalacheck.Arbitrary.arbitrary
 
-import org.joda.time._
+import com.fortysevendeg.scalacheck.datetime.typeclasses._
 
 /**
   * Some generators for working with dates and times.
   */
 object GenDateTime {
-
-
-  /** A <code>Years</code> period generator. */
-  val genYearsPeriod: Gen[Years] = Gen.choose(-292275054, 292278993).map(Years.ZERO.plus(_)) // Years.MIN_VALUE produces exception-throwing results
-
-  /** A <code>Months</code> period generator. */
-  val genMonthsPeriod: Gen[Months] = Gen.choose(Months.MIN_VALUE.getMonths, Months.MAX_VALUE.getMonths).map(Months.ZERO.plus(_))
-
-  /** A <code>Weeks</code> period generator. */
-  val genWeeksPeriod: Gen[Weeks] = Gen.choose(Weeks.MIN_VALUE.getWeeks, Weeks.MAX_VALUE.getWeeks).map(Weeks.ZERO.plus(_))
-
-  /** A <code>Days</code> period generator. */
-  val genDaysPeriod: Gen[Days] = Gen.choose(Days.MIN_VALUE.getDays, Days.MAX_VALUE.getDays).map(Days.ZERO.plus(_))
-
-  /** A <code>Hours</code> period generator. */
-  val genHoursPeriod: Gen[Hours] = Gen.choose(Hours.MIN_VALUE.getHours, Hours.MAX_VALUE.getHours).map(Hours.ZERO.plus(_))
-
-  /** A <code>Minutes</code> period generator. */
-  val genMinutesPeriod: Gen[Minutes] = Gen.choose(Minutes.MIN_VALUE.getMinutes, Minutes.MAX_VALUE.getMinutes).map(Minutes.ZERO.plus(_))
-
-  /** A <code>Seconds</code> period generator. */
-  val genSecondsPeriod: Gen[Seconds] = Gen.choose(Seconds.MIN_VALUE.getSeconds, Seconds.MAX_VALUE.getSeconds).map(Seconds.ZERO.plus(_))
-
-  /**
-    * A <code>Period</code> generator consisting of years, days, hours, minutes, seconds and millis.
-    */
-  val genPeriod: Gen[Period] = for {
-    years <- genYearsPeriod
-    days <- Gen.choose(1, 365)
-    hours <- Gen.choose(0, 23)
-    minutes <- Gen.choose(0, 59)
-    seconds <- Gen.choose(0, 59)
-    millis <- Gen.choose(0, 999)
-  } yield Period.years(years.getYears).withDays(days).withHours(hours).withMinutes(minutes).withSeconds(seconds).withMillis(millis)
 
   /**
     * Generates a <code>DateTime</code> between the given <code>dateTime</code>x and the end of the <code>period</code>
@@ -50,8 +16,10 @@ object GenDateTime {
     * @param period An offset from <code>dateTime</code>, serving as an upper bound for generated <code>DateTime</code>s. Can be negative, denoting an offset <i>before</i> the provided <code>DateTime</code>.
     * @return A <code>DateTime</code> generator for <code>DateTime</code>s within the expected range.
     */
-  def genDateTimeWithinPeriod(dateTime: DateTime, period: ReadablePeriod): Gen[DateTime] = {
-    val diffMillis = dateTime.plus(period).getMillis() - dateTime.getMillis()
-    Gen.choose(0L min diffMillis, 0L max diffMillis).map(millis => dateTime.plus(millis))
+  def genDateTimeWithinPeriod[D, R](dateTime: D, range: R)(implicit scDateTime: ScalaCheckDateTimeInfra[D, R]): Gen[D] = {
+
+    val diffMillis = scDateTime.getMillis(scDateTime.addRange(dateTime, range)) - scDateTime.getMillis(dateTime)
+
+    Gen.choose(0L min diffMillis, 0L max diffMillis).map(millis => scDateTime.addMillis(dateTime, millis))
   }
 }

--- a/src/main/scala/com/fortysevendeg/scalacheck/datetime/GenDateTime.scala
+++ b/src/main/scala/com/fortysevendeg/scalacheck/datetime/GenDateTime.scala
@@ -16,10 +16,8 @@ object GenDateTime {
     * @param period An offset from <code>dateTime</code>, serving as an upper bound for generated <code>DateTime</code>s. Can be negative, denoting an offset <i>before</i> the provided <code>DateTime</code>.
     * @return A <code>DateTime</code> generator for <code>DateTime</code>s within the expected range.
     */
-  def genDateTimeWithinPeriod[D, R](dateTime: D, range: R)(implicit scDateTime: ScalaCheckDateTimeInfra[D, R]): Gen[D] = {
-
+  def genDateTimeWithinRange[D, R](dateTime: D, range: R)(implicit scDateTime: ScalaCheckDateTimeInfra[D, R]): Gen[D] = {
     val diffMillis = scDateTime.getMillis(scDateTime.addRange(dateTime, range)) - scDateTime.getMillis(dateTime)
-
     Gen.choose(0L min diffMillis, 0L max diffMillis).map(millis => scDateTime.addMillis(dateTime, millis))
   }
 }

--- a/src/main/scala/com/fortysevendeg/scalacheck/datetime/instances/j8.scala
+++ b/src/main/scala/com/fortysevendeg/scalacheck/datetime/instances/j8.scala
@@ -1,3 +1,15 @@
 package com.fortysevendeg.scalacheck.datetime.instances
 
-trait J8Instances
+import com.fortysevendeg.scalacheck.datetime.typeclasses._
+import java.time._
+import java.time.temporal.ChronoUnit.MILLIS
+
+trait J8Instances {
+
+  implicit val j8ForDuration: ScalaCheckDateTimeInfra[ZonedDateTime, Duration] = new ScalaCheckDateTimeInfra[ZonedDateTime, Duration] {
+    def addRange(zonedDateTime: ZonedDateTime, duration: Duration): ZonedDateTime = zonedDateTime.plus(duration)
+    def addMillis(zonedDateTime: ZonedDateTime, millis: Long): ZonedDateTime = zonedDateTime.plus(millis, MILLIS)
+    def getMillis(zonedDateTime: ZonedDateTime): Long = zonedDateTime.toInstant.toEpochMilli
+  }
+
+}

--- a/src/main/scala/com/fortysevendeg/scalacheck/datetime/instances/j8.scala
+++ b/src/main/scala/com/fortysevendeg/scalacheck/datetime/instances/j8.scala
@@ -1,0 +1,3 @@
+package com.fortysevendeg.scalacheck.datetime.instances
+
+trait J8Instances

--- a/src/main/scala/com/fortysevendeg/scalacheck/datetime/instances/joda.scala
+++ b/src/main/scala/com/fortysevendeg/scalacheck/datetime/instances/joda.scala
@@ -6,8 +6,7 @@ import org.joda.time._
 trait JodaInstances {
 
   // todo have another instance with Duration rather than period?
-  implicit val dateTime: ScalaCheckDateTimeInfra[DateTime, Period] = new ScalaCheckDateTimeInfra[DateTime, Period] {
-    type RangeForA = Period
+  implicit val jodaForPeriod: ScalaCheckDateTimeInfra[DateTime, Period] = new ScalaCheckDateTimeInfra[DateTime, Period] {
     def addRange(dateTime: DateTime, period: Period): DateTime = dateTime.plus(period)
     def addMillis(dateTime: DateTime, millis: Long): DateTime =  dateTime.plus(millis)
     def getMillis(dateTime: DateTime): Long = dateTime.getMillis

--- a/src/main/scala/com/fortysevendeg/scalacheck/datetime/instances/joda.scala
+++ b/src/main/scala/com/fortysevendeg/scalacheck/datetime/instances/joda.scala
@@ -1,0 +1,15 @@
+package com.fortysevendeg.scalacheck.datetime.instances
+
+import com.fortysevendeg.scalacheck.datetime.typeclasses._
+import org.joda.time._
+
+trait JodaInstances {
+
+  // todo have another instance with Duration rather than period?
+  implicit val dateTime: ScalaCheckDateTimeInfra[DateTime, Period] = new ScalaCheckDateTimeInfra[DateTime, Period] {
+    type RangeForA = Period
+    def addRange(dateTime: DateTime, period: Period): DateTime = dateTime.plus(period)
+    def addMillis(dateTime: DateTime, millis: Long): DateTime =  dateTime.plus(millis)
+    def getMillis(dateTime: DateTime): Long = dateTime.getMillis
+  }
+}

--- a/src/main/scala/com/fortysevendeg/scalacheck/datetime/instances/package.scala
+++ b/src/main/scala/com/fortysevendeg/scalacheck/datetime/instances/package.scala
@@ -1,0 +1,6 @@
+package com.fortysevendeg.scalacheck.datetime
+
+package object instances {
+  object joda extends JodaInstances
+  object j8 extends J8Instances
+}

--- a/src/main/scala/com/fortysevendeg/scalacheck/datetime/j8/GenJ8.scala
+++ b/src/main/scala/com/fortysevendeg/scalacheck/datetime/j8/GenJ8.scala
@@ -1,0 +1,26 @@
+package com.fortysevendeg.scalacheck.datetime.j8
+
+import collection.JavaConverters._
+
+import org.scalacheck.Gen
+import org.scalacheck.Arbitrary.arbitrary
+
+import java.time._
+import java.time.temporal.ChronoUnit.MILLIS
+
+object GenJ8 {
+
+  val genZonedDateTime: Gen[ZonedDateTime] = for {
+    year <- Gen.choose(-292278994, 292278994)
+    month <- Gen.choose(1, 12)
+    maxDaysInMonth = Month.of(month).length(Year.of(year).isLeap)
+    dayOfMonth <- Gen.choose(1, maxDaysInMonth)
+    hour <- Gen.choose(0, 23)
+    minute <- Gen.choose(0, 59)
+    second <- Gen.choose(0, 59)
+    nanoOfSecond <- Gen.choose(0, 999999999)
+    zoneId <- Gen.oneOf(ZoneId.getAvailableZoneIds.asScala.toList)
+  } yield ZonedDateTime.of(year, month, dayOfMonth, hour, minute, second, nanoOfSecond, ZoneId.of(zoneId))
+
+  val genDuration: Gen[Duration] = Gen.choose(Long.MinValue, Long.MaxValue / 1000).map(l => Duration.of(l, MILLIS))
+}

--- a/src/main/scala/com/fortysevendeg/scalacheck/datetime/joda/GenJoda.scala
+++ b/src/main/scala/com/fortysevendeg/scalacheck/datetime/joda/GenJoda.scala
@@ -1,0 +1,44 @@
+package com.fortysevendeg.scalacheck.datetime.joda
+
+import org.scalacheck.Gen
+import org.joda.time._
+
+/**
+  * Generators specific for Joda time.
+  */
+object GenJoda {
+
+    /** A <code>Years</code> period generator. */
+  val genYearsPeriod: Gen[Years] = Gen.choose(-292275054, 292278993).map(Years.ZERO.plus(_)) // Years.MIN_VALUE produces exception-throwing results
+
+  /** A <code>Months</code> period generator. */
+  val genMonthsPeriod: Gen[Months] = Gen.choose(Months.MIN_VALUE.getMonths, Months.MAX_VALUE.getMonths).map(Months.ZERO.plus(_))
+
+  /** A <code>Weeks</code> period generator. */
+  val genWeeksPeriod: Gen[Weeks] = Gen.choose(Weeks.MIN_VALUE.getWeeks, Weeks.MAX_VALUE.getWeeks).map(Weeks.ZERO.plus(_))
+
+  /** A <code>Days</code> period generator. */
+  val genDaysPeriod: Gen[Days] = Gen.choose(Days.MIN_VALUE.getDays, Days.MAX_VALUE.getDays).map(Days.ZERO.plus(_))
+
+  /** A <code>Hours</code> period generator. */
+  val genHoursPeriod: Gen[Hours] = Gen.choose(Hours.MIN_VALUE.getHours, Hours.MAX_VALUE.getHours).map(Hours.ZERO.plus(_))
+
+  /** A <code>Minutes</code> period generator. */
+  val genMinutesPeriod: Gen[Minutes] = Gen.choose(Minutes.MIN_VALUE.getMinutes, Minutes.MAX_VALUE.getMinutes).map(Minutes.ZERO.plus(_))
+
+  /** A <code>Seconds</code> period generator. */
+  val genSecondsPeriod: Gen[Seconds] = Gen.choose(Seconds.MIN_VALUE.getSeconds, Seconds.MAX_VALUE.getSeconds).map(Seconds.ZERO.plus(_))
+
+  /**
+    * A <code>Period</code> generator consisting of years, days, hours, minutes, seconds and millis.
+    */
+  val genPeriod: Gen[Period] = for {
+    years <- genYearsPeriod
+    days <- Gen.choose(1, 365)
+    hours <- Gen.choose(0, 23)
+    minutes <- Gen.choose(0, 59)
+    seconds <- Gen.choose(0, 59)
+    millis <- Gen.choose(0, 999)
+  } yield Period.years(years.getYears).withDays(days).withHours(hours).withMinutes(minutes).withSeconds(seconds).withMillis(millis)
+
+}

--- a/src/main/scala/com/fortysevendeg/scalacheck/datetime/typeclasses/ScalaCheckDateTimeInfra.scala
+++ b/src/main/scala/com/fortysevendeg/scalacheck/datetime/typeclasses/ScalaCheckDateTimeInfra.scala
@@ -1,0 +1,13 @@
+package com.fortysevendeg.scalacheck.datetime.typeclasses
+
+/*
+ * TODO:
+ *  - Use simulacrum?
+ *  - Rename this
+ *  - Try the Aux pattern to remove the range type param?
+ */
+trait ScalaCheckDateTimeInfra[D, R] {
+  def addRange(dateTime: D, range: R): D
+  def addMillis(dateTime: D, millis: Long): D
+  def getMillis(dateTime: D): Long
+}

--- a/src/test/scala/com/fortysevendeg/scalacheck/datetime/j8/GenJ8Properties.scala
+++ b/src/test/scala/com/fortysevendeg/scalacheck/datetime/j8/GenJ8Properties.scala
@@ -1,0 +1,52 @@
+package com.fortysevendeg.scalacheck.datetime.j8
+
+import scala.util.Try
+
+import org.scalacheck._
+import org.scalacheck.Prop._
+
+import java.time._
+
+import com.fortysevendeg.scalacheck.datetime.GenDateTime._
+import com.fortysevendeg.scalacheck.datetime.instances.j8._
+
+import GenJ8._
+
+object GenJ8Properties extends Properties("Java 8 Generators") {
+
+  property("genDuration creates valid durations") = forAll(genDuration) { _ => passed }
+
+  property("genZonedDateTime created valid times") = forAll(genZonedDateTime) { _ => passed }
+
+  // Guards against adding a duration to a datetime which cannot represent millis in a long, causing an exception.
+  private[this] def tooLargeForAddingRanges(dateTime: ZonedDateTime, d: Duration): Boolean = {
+    Try(dateTime.plus(d).toInstant().toEpochMilli()).isFailure
+  }
+
+  property("genDuration can be added to any date") = forAll(genZonedDateTime, genDuration) { (dt, dur) =>
+    !tooLargeForAddingRanges(dt, dur) ==> {
+      val attempted = Try(dt.plus(dur).toInstant().toEpochMilli())
+      attempted.isSuccess :|  attempted.toString
+    }
+  }
+
+  property("genDateTimeWithinRange for Java 8 should generate ZonedDateTimes between the given date and the end of the specified Duration") = forAll(genZonedDateTime, genDuration) { (now, d) =>
+    !tooLargeForAddingRanges(now, d) ==> {
+      forAll(genDateTimeWithinRange(now, d)) { generated =>
+        val durationBoundary = now.plus(d)
+
+        val resultText = s"""Duration:        $d
+                            |Now:             $now
+                            |Generated:       $generated
+                            |Period Boundary: $durationBoundary""".stripMargin
+
+        val (lowerBound, upperBound) = if(durationBoundary.isAfter(now)) (now, durationBoundary) else (durationBoundary, now)
+
+        val check = (lowerBound.isBefore(generated) || lowerBound.isEqual(generated)) &&
+                    (upperBound.isAfter(generated)  || upperBound.isEqual(generated))
+
+        check :| resultText
+      }
+    }
+  }
+}

--- a/src/test/scala/com/fortysevendeg/scalacheck/datetime/joda/GenJodaProperties.scala
+++ b/src/test/scala/com/fortysevendeg/scalacheck/datetime/joda/GenJodaProperties.scala
@@ -11,7 +11,7 @@ import com.fortysevendeg.scalacheck.datetime.instances.joda._
 
 import GenJoda._
 
-object GenJodaProperties extends Properties("Date Time Generators") {
+object GenJodaProperties extends Properties("Joda Generators") {
 
   /*
    * These properties check that the construction of the periods does not fail. Some (like years) have a restricted range of values.
@@ -33,11 +33,11 @@ object GenJodaProperties extends Properties("Date Time Generators") {
 
   property("genPeriod creates valid periods containing a selection of other periods") = forAll(genPeriod) { _ => passed }
 
-  property("genDateTimeWithinPeriod should generate DateTimes between the given date and the end of the specified period") = forAll(genPeriod) { p =>
+  property("genDateTimeWithinRange for Joda should generate DateTimes between the given date and the end of the specified Period") = forAll(genPeriod) { p =>
 
     val now = new DateTime()
 
-    forAll(genDateTimeWithinPeriod(now, p)) { generated =>
+    forAll(genDateTimeWithinRange(now, p)) { generated =>
 
       // if period is negative, then periodBoundary will be before now
       val periodBoundary = now.plus(p)

--- a/src/test/scala/com/fortysevendeg/scalacheck/datetime/joda/GenJodaProperties.scala
+++ b/src/test/scala/com/fortysevendeg/scalacheck/datetime/joda/GenJodaProperties.scala
@@ -1,4 +1,4 @@
-package com.fortysevendeg.scalacheck.datetime
+package com.fortysevendeg.scalacheck.datetime.joda
 
 import org.scalacheck._
 import org.scalacheck.Prop._
@@ -6,9 +6,12 @@ import org.scalacheck.Prop._
 import org.joda.time._
 import org.joda.time.format.PeriodFormat
 
-import GenDateTime._
+import com.fortysevendeg.scalacheck.datetime.GenDateTime._
+import com.fortysevendeg.scalacheck.datetime.instances.joda._
 
-object GenDateTimeProperties extends Properties("Date Time Generators") {
+import GenJoda._
+
+object GenJodaProperties extends Properties("Date Time Generators") {
 
   /*
    * These properties check that the construction of the periods does not fail. Some (like years) have a restricted range of values.


### PR DESCRIPTION
This PR is a first stab at including support for other datetime libraries as well as Joda. This allows the generators to work with Java 8's `java.time` library.

You can now call `genDateTimeWithinRange` with, for instance, a Joda `DateTime` and `Period`, or a Java8 `ZonedDateTime` and `Duration`, and it should return the appropriate type.

How this works:
`genDateTimeWithinRange` takes an implicit `ScalaCheckDateTimeInfra` type, which is parameterized on the date class and the "range". As long as an implicit exists for that date/range pair, then this works. For this PR, Joda `DateTime` and `Period` and Java8 `ZonedDateTime` and `Duration` are included, but there's no reason not to include more, such as Joda `DateTime` with Joda `Duration`, or the other incarnations of Java8's `DateTime`s that are not `Zoned`.

To the end-user, the generators such as `genDateTimeWithinRange` should "just work", without needing to understand `ScalaCheckDateTimeInfra` - just having the correct imports should be fine.

By example, to work with Java 8, these imports are needed:
```
import com.fortysevendeg.scalacheck.datetime.GenDateTime._
import com.fortysevendeg.scalacheck.datetime.instances.j8._
```

and `... instances.joda._` exists too.

Right now, the `ScalaCheckDateTimeInfra` expects to be able to convert whatever classes are provided to millis. I'm pretty sure I can take another look at this and remove that restriction (especially as Java 8 has nanosecond granularity). Another reason is that this PR uncovered some crazy stuff with Java 8's library, such as getting the milliseconds of a Date that can't be represented by milliseconds throws an arithmetic exception"

Again, I'd love some feedback if possible, especially around the naming (I hate `ScalaCheckDateTimeInfra`) and the general approach taken.

Resolves #2 