### PR TITLE
Issue 8 publish

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val docsSettings =
 
 lazy val root = (project in file("."))
   .settings(moduleName := "scalacheck-datetime")
-  .settings(version := "0.1.0-SNAPSHOT")
+  .settings(version := "0.1.0")
   .settings(scalacheckDatetimeSettings:_ *)
 
 lazy val docs = (project in file("docs"))

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val docsSettings =
 
 lazy val root = (project in file("."))
   .settings(moduleName := "scalacheck-datetime")
-  .settings(version := "0.0.1-SNAPSHOT")
+  .settings(version := "0.1.0-SNAPSHOT")
   .settings(scalacheckDatetimeSettings:_ *)
 
 lazy val docs = (project in file("docs"))

--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,7 @@ lazy val docsSettings =
 
 lazy val root = (project in file("."))
   .settings(moduleName := "scalacheck-datetime")
+  .settings(version := "0.0.1-SNAPSHOT")
   .settings(scalacheckDatetimeSettings:_ *)
 
 lazy val docs = (project in file("docs"))

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val docsSettings =
 
 lazy val root = (project in file("."))
   .settings(moduleName := "scalacheck-datetime")
-  .settings(version := "0.1.0")
+  .settings(version := "0.2.0-SNAPSHOT")
   .settings(scalacheckDatetimeSettings:_ *)
 
 lazy val docs = (project in file("docs"))

--- a/docs/src/tut/docs.md
+++ b/docs/src/tut/docs.md
@@ -11,6 +11,8 @@ Any issues, suggestions or criticisms are more than welcome.
 For SBT, you can add the dependency to your project's build file:
 
 ```scala
+resolvers += Resolver.sonatypeRepo("releases")
+
 "com.fortysevendeg" %% "scalacheck-datetime" % "0.1.0" % "test"
 ```
 

--- a/docs/src/tut/docs.md
+++ b/docs/src/tut/docs.md
@@ -11,12 +11,12 @@ Any issues, suggestions or criticisms are more than welcome.
 For SBT, you can add the dependency to your project's build file:
 
 ```scala
-"com.fortysevendeg" %% "scalacheck-datetime" % "0.1-SNAPSHOT"
+"com.fortysevendeg" %% "scalacheck-datetime" % "0.1.0" % "test"
 ```
 
 # Current Status
 
-As of version 0.1, the following libraries and classes are supported:
+As of version 0.1.0, the following libraries and classes are supported:
 
   * [Joda Time](http://www.joda.org/joda-time/): The [`DateTime`](http://joda-time.sourceforge.net/apidocs/org/joda/time/DateTime.html) class, and [`Period`](http://joda-time.sourceforge.net/apidocs/org/joda/time/Period.html) for specifying a range of time.
   * [Java SE 8 Date and Time](http://www.oracle.com/technetwork/articles/java/jf14-date-time-2125367.html): The [`ZonedDateTime`](https://docs.oracle.com/javase/8/docs/api/java/time/ZonedDateTime.html) and [`Duration`](https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html) classes.

--- a/docs/src/tut/index.md
+++ b/docs/src/tut/index.md
@@ -20,7 +20,7 @@ arbitrary[DateTime].sample
 ### Installation
 
 ```scala
-"com.fortysevendeg" %% "scalacheck-datetime" % "0.1-SNAPSHOT"
+"com.fortysevendeg" %% "scalacheck-datetime" % "0.1.0" % "test"
 ```
 
 

--- a/docs/src/tut/index.md
+++ b/docs/src/tut/index.md
@@ -20,6 +20,8 @@ arbitrary[DateTime].sample
 ### Installation
 
 ```scala
+resolvers += Resolver.sonatypeRepo("releases")
+
 "com.fortysevendeg" %% "scalacheck-datetime" % "0.1.0" % "test"
 ```
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4" exclude("com.typesafe.
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.0.0")
+
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")

--- a/publish.sbt
+++ b/publish.sbt
@@ -1,0 +1,56 @@
+organizationName := "47 Degrees"
+
+organizationHomepage := Some(new URL("http://47deg.com"))
+
+publishMavenStyle := true
+
+startYear := Some(2016)
+
+description := "A library for helping use date and time libraries with ScalaCheck"
+
+homepage := Some(url("http://47deg.com"))
+
+scmInfo := Some(ScmInfo(url("https://github.com/47deg/scalacheck-datetime"), "https://github.com/47deg/scalacheck-datetime.git"))
+
+licenses := Seq("Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+
+pomExtra :=
+    <developers>
+      <developer>
+        <name>47 Degrees (twitter: @47deg)</name>
+        <email>hello@47deg.com</email>
+      </developer>
+      <developer>
+        <name>47 Degrees</name>
+      </developer>
+    </developers>
+
+publishTo := {
+  val nexus = "https://oss.sonatype.org/"
+  if (isSnapshot.value)
+    Some("snapshots" at nexus + "content/repositories/snapshots")
+  else
+    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+}
+
+lazy val gpgFolder = sys.env.getOrElse("GPG_FOLDER", ".")
+
+pgpPassphrase := Some(sys.env.getOrElse("GPG_PASSPHRASE", "").toCharArray)
+
+pgpPublicRing := file(s"$gpgFolder/pubring.gpg")
+
+pgpSecretRing := file(s"$gpgFolder/secring.gpg")
+
+credentials += Credentials("Sonatype Nexus Repository Manager",
+  "oss.sonatype.org",
+  sys.env.getOrElse("PUBLISH_USERNAME", ""),
+  sys.env.getOrElse("PUBLISH_PASSWORD", ""))
+
+publishArtifact in Test := false
+
+lazy val publishSnapshot = taskKey[Unit]("Publish only if the version is a SNAPSHOT")
+
+publishSnapshot := Def.taskDyn {
+  if (isSnapshot.value) Def.task { PgpKeys.publishSigned.value }
+  else Def.task(println("Actual version is not a Snapshot. Skipping publish."))
+}.value


### PR DESCRIPTION
SBT configuration for publishing. 0.1.0 has been [released](https://oss.sonatype.org/content/repositories/releases/com/fortysevendeg/scalacheck-datetime_2.11/0.1.0/) - documentation updated to reflect this.

@rafaparadela - would you be able to review this please?

Many thanks!

Resolves #8 