### PR TITLE
Fix issue with times being generated in the DST gap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ scala:
    - 2.12.0
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION clean coverage test docs/tut
+  - sbt ++$TRAVIS_SCALA_VERSION clean coverage "test-only * -- -minSuccessfulTests 100000" docs/tut
 
 jdk:
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ scala:
    - 2.12.0
 
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION clean coverage "test-only * -- -minSuccessfulTests 100000" docs/tut
+  - sbt ++$TRAVIS_SCALA_VERSION clean coverage "test-only * -- -minSuccessfulTests 1000000" docs/tut
 
 jdk:
   - oraclejdk8

--- a/src/main/scala/com/fortysevendeg/scalacheck/datetime/jdk8/granularity/package.scala
+++ b/src/main/scala/com/fortysevendeg/scalacheck/datetime/jdk8/granularity/package.scala
@@ -26,7 +26,12 @@ package object granularity {
   }
 
   implicit val years: Granularity[ZonedDateTime] = new Granularity[ZonedDateTime] {
-    val normalize = (dt: ZonedDateTime) => dt.withNano(0).withSecond(0).withMinute(0).withHour(0).withDayOfYear(1)
+    // Set the day of year before the hour as some days (very very rarely) start at 1am.
+    // It is therefore possible to set the hour of day to zero on a day where it starts at 1am.
+    // So Java 8 sets the hour to 1am.
+    // If you then set the day of year to Jan 1, and that day starts at 12am,
+    // then the granularity has been set wrong in that case. Insane.
+    val normalize = (dt: ZonedDateTime) => dt.withDayOfYear(1).withNano(0).withSecond(0).withMinute(0).withHour(0)
     val description = "Years"
   }
 }

--- a/src/main/scala/com/fortysevendeg/scalacheck/datetime/joda/GenJoda.scala
+++ b/src/main/scala/com/fortysevendeg/scalacheck/datetime/joda/GenJoda.scala
@@ -46,9 +46,9 @@ trait GenJoda {
 
   /** A <code>DateTime</code> generator. */
   def genDateTime(implicit granularity: Granularity[DateTime]): Gen[DateTime] = for {
-    year <- Gen.choose(-292275055,292278994)
+    year <- Gen.choose(-292275054,292278993)
     month <- Gen.choose(1, 12)
-    yearAndMonthDt = new DateTime(year, month, 1, 0, 0)
+    yearAndMonthDt <- Try(Gen.const(new DateTime(year, month, 1, 0, 0))).getOrElse(Gen.fail)
     dayOfMonth <- Gen.choose(1, yearAndMonthDt.dayOfMonth.getMaximumValue)
     hourOfDay <- Gen.choose(0, 23)
     minuteOfHour <- Gen.choose(0, 59)

--- a/src/main/scala/com/fortysevendeg/scalacheck/datetime/joda/GenJoda.scala
+++ b/src/main/scala/com/fortysevendeg/scalacheck/datetime/joda/GenJoda.scala
@@ -2,6 +2,8 @@ package com.fortysevendeg.scalacheck.datetime.joda
 
 import com.fortysevendeg.scalacheck.datetime.Granularity
 
+import scala.util.Try
+
 import org.scalacheck.Gen
 import org.scalacheck.Arbitrary
 import org.joda.time._
@@ -52,7 +54,8 @@ trait GenJoda {
     minuteOfHour <- Gen.choose(0, 59)
     secondOfMinute <- Gen.choose(0, 59)
     millisOfSecond <- Gen.choose(0, 999)
-  } yield granularity.normalize(new DateTime(year, month, dayOfMonth, hourOfDay, minuteOfHour, secondOfMinute, millisOfSecond))
+    attempt <- Try(Gen.const(new DateTime(year, month, dayOfMonth, hourOfDay, minuteOfHour, secondOfMinute, millisOfSecond))).getOrElse(Gen.fail)
+  } yield granularity.normalize(attempt)
 }
 
 object GenJoda extends GenJoda

--- a/src/test/scala/com/fortysevendeg/scalacheck/datetime/joda/GenJodaProperties.scala
+++ b/src/test/scala/com/fortysevendeg/scalacheck/datetime/joda/GenJodaProperties.scala
@@ -75,9 +75,7 @@ object GenJodaProperties extends Properties("Joda Generators") {
     implicit val generatedGranularity = granularity
 
     val now = new DateTime()
-
     forAll(genDateTimeWithinRange(now, period)) { generated =>
-
       // if period is negative, then periodBoundary will be before now
       val periodBoundary = now.plus(period)
 

--- a/src/test/scala/com/fortysevendeg/scalacheck/datetime/joda/GenJodaProperties.scala
+++ b/src/test/scala/com/fortysevendeg/scalacheck/datetime/joda/GenJodaProperties.scala
@@ -41,6 +41,7 @@ object GenJodaProperties extends Properties("Joda Generators") {
     import ArbitraryJoda._
     forAll { dt: DateTime => passed }
   }
+
   val granularitiesAndPredicates: List[(Granularity[DateTime], DateTime => Boolean)] = {
 
     def zeroMillis(dt: DateTime)  =                    dt.getMillisOfSecond == 0


### PR DESCRIPTION
Increased the number of ScalaCheck tests to expose this issue, too.

@franciscodr @raulraja @diesalbla would you be able to take a look please?

Fixes #15.